### PR TITLE
Make the UI login automatic

### DIFF
--- a/deploy/clowdapp.yaml
+++ b/deploy/clowdapp.yaml
@@ -161,6 +161,8 @@ objects:
       jmx.rmiserver.port=8081
       jmx.rmiregistry.port=8081
       query.max-length=10000000
+      web-ui.authentication.type=fixed
+      web-ui.user=presto
     jvm.config: >-
       -server
 


### PR DESCRIPTION
## Summary
This sets the UI login to fixed with a default user name for our clowdapp configmap. This will make checking the UI ultimately easier via turnpike as it should eliminate the redirect to a login screen.