### PR TITLE
add alternative header param to clowdapp config

### DIFF
--- a/build_deploy.sh
+++ b/build_deploy.sh
@@ -20,10 +20,13 @@ fi
 #     exit 1
 # fi
 
-DOCKER_CONF="$PWD/.docker"
-mkdir -p "$DOCKER_CONF"
-docker --config="$DOCKER_CONF" login -u="$QUAY_USER" -p="$QUAY_TOKEN" quay.io
-# docker --config="$DOCKER_CONF" login -u="$RH_REGISTRY_USER" -p="$RH_REGISTRY_TOKEN" registry.redhat.io
-docker --config="$DOCKER_CONF" build -t "${IMAGE}:${IMAGE_TAG}" ${SCRIPT_DIR}
-docker --config="$DOCKER_CONF" push "${IMAGE}:${IMAGE_TAG}"
-docker --config="$DOCKER_CONF" logout
+changed=$(git diff --name-only ^HEAD~1|| egrep -v deploy/clowdapp.yaml) # do not build if only the `deploy/clowdapp.yaml` file has changed
+if [ -n "$changed" ]; then
+    DOCKER_CONF="$PWD/.docker"
+    mkdir -p "$DOCKER_CONF"
+    docker --config="$DOCKER_CONF" login -u="$QUAY_USER" -p="$QUAY_TOKEN" quay.io
+    # docker --config="$DOCKER_CONF" login -u="$RH_REGISTRY_USER" -p="$RH_REGISTRY_TOKEN" registry.redhat.io
+    docker --config="$DOCKER_CONF" build -t "${IMAGE}:${IMAGE_TAG}" ${SCRIPT_DIR}
+    docker --config="$DOCKER_CONF" push "${IMAGE}:${IMAGE_TAG}"
+    docker --config="$DOCKER_CONF" logout
+fi

--- a/deploy/clowdapp.yaml
+++ b/deploy/clowdapp.yaml
@@ -187,6 +187,7 @@ objects:
       query.max-total-memory-per-node=${QUERY_MAX_TOTAL_MEMORY_PER_NODE}
       web-ui.authentication.type=fixed
       web-ui.user=trino
+      protocol.v1.alternate-header-name=Presto
     config.properties.worker: |-
       coordinator=false
       node-scheduler.include-coordinator=true
@@ -196,6 +197,7 @@ objects:
       query.max-memory=${QUERY_MAX_MEMORY}
       query.max-memory-per-node=${QUERY_MAX_MEMORY_PER_NODE}
       query.max-total-memory-per-node=${QUERY_MAX_TOTAL_MEMORY_PER_NODE}
+      protocol.v1.alternate-header-name=Presto
 - apiVersion: v1
   kind: ConfigMap
   metadata:


### PR DESCRIPTION
This adds `protocol.v1.alternate-header-name=Presto` to the Trino configuration so that the current version of koku will work without upgrading to the trino python client.

This PR also adds a gate to the `build_deploy.sh` script so that if we _only_ update the `clowdapp.yaml`, we do not rebuild the image.