### PR TITLE
update hive config

### DIFF
--- a/deploy/clowdapp.yaml
+++ b/deploy/clowdapp.yaml
@@ -1,4 +1,4 @@
-apiVersion: v1
+apiVersion: template.openshift.io/v1
 kind: Template
 metadata:
   name: trino-template
@@ -281,6 +281,9 @@ objects:
           type: GAUGE
     hive.properties: |-
       connector.name=hive-hadoop2
+      hive.allow-add-column=true
+      hive.allow-drop-column=true
+      hive.allow-rename-column=true
       hive.allow-drop-table=true
       hive.allow-rename-table=true
       hive.collect-column-statistics-on-write=true


### PR DESCRIPTION
1. update apiVersion because of:
```
Using non-groupfied API resources is deprecated and will be removed in a future release, update apiVersion to "template.openshift.io/v1" for your resource
```
2. Enable more Hive configuration