### PR TITLE
COST-3130: Add kube linter to ignore min three replica

### DIFF
--- a/deploy/clowdapp.yaml
+++ b/deploy/clowdapp.yaml
@@ -321,6 +321,9 @@ objects:
     envName: ${ENV_NAME}
     deployments:
     - name: coordinator
+      metadata:
+        annotations:
+          ignore-check.kube-linter.io/minimum-three-replicas: This deployment uses 1 pod as currently the coordinator is a singleton
       minReplicas: ${{COORDINATOR_REPLICAS}}
       webServices:
         public:


### PR DESCRIPTION
* Trino coordinator is a single replica deployment
* Add annotation to ClowdApp