### PR TITLE
Update check-image workaround to avoid use of ENV variables

### DIFF
--- a/.github/workflows/check-image.yml
+++ b/.github/workflows/check-image.yml
@@ -14,7 +14,7 @@ jobs:
         run: sudo apt-get install -y skopeo
       - name: Check change
         run: |
-          UBI_VERSION=8.6 skopeo inspect "docker://$(grep -Po '(?<=FROM )([^"]+)' Dockerfile)" | grep -Po '(?<="Digest": ")([^"]+)' > .baseimagedigest
+          skopeo inspect "docker://registry.access.redhat.com/ubi8/ubi:8.6" | grep -Po '(?<="Digest": ")([^"]+)' > .baseimagedigest
           docker run --rm --entrypoint sh -u 0 quay.io/cloudservices/ubi-trino:latest -c \
             'yum upgrade -y --security > /dev/null; rpm -qa | sort | sha256sum' \
             >> .baseimagedigest

--- a/README.md
+++ b/README.md
@@ -26,6 +26,8 @@ Docker Image build from RHEL UBI base image
 9. Create a PR, this should execute a PR check script.
 10. If successful, get approval and merge.
 
+* Note: If the UBI image version is updated in the Dockerfile you must also update the `check-image.yml` workflow.
+
 # Utility Scripts
 
 * `check_upstream.sh` : Check the current version of trino set in the Dockerfile against release tags from the `trinodb/trino` repo.


### PR DESCRIPTION
* Update workaround to avoid ENV variables

Debugged GHA using tmate in a fork