### PR TITLE
Update clowdapp.yaml

### DIFF
--- a/deploy/clowdapp.yaml
+++ b/deploy/clowdapp.yaml
@@ -502,6 +502,10 @@ objects:
           - name: MAX_HEAP_SIZE
             value: ${MAX_HEAP_SIZE}
         machinePool: ${MACHINE_POOL_OPTION}
+        tolerations:
+          - effect: NoSchedule  
+            key: hccm-trino-node
+            value: 'true'
         resources:
           limits:
             cpu: ${WORKER_CPU_LIMIT}


### PR DESCRIPTION
Add the hccm-trino-node toleration which enables the worker pod to deploy on the memory-optimized nodes