### PR TITLE
unpin UBI version

### DIFF
--- a/.github/workflows/check-image.yml
+++ b/.github/workflows/check-image.yml
@@ -14,7 +14,7 @@ jobs:
         run: sudo apt-get install -y skopeo
       - name: Check change
         run: |
-          skopeo inspect "docker://registry.access.redhat.com/ubi8/ubi:8.6" | grep -Po '(?<="Digest": ")([^"]+)' > .baseimagedigest
+          skopeo inspect "docker://registry.access.redhat.com/ubi8/ubi:latest" | grep -Po '(?<="Digest": ")([^"]+)' > .baseimagedigest
           docker run --rm --entrypoint sh -u 0 quay.io/cloudservices/ubi-trino:latest -c \
             'yum upgrade -y --security > /dev/null; rpm -qa | sort | sha256sum' \
             >> .baseimagedigest

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,8 +1,7 @@
 ARG PROMETHEUS_VERSION=0.17.0
 ARG TRINO_VERSION=418
-ARG UBI_VERSION=8.8
 
-FROM registry.access.redhat.com/ubi8/ubi:${UBI_VERSION} as downloader
+FROM registry.access.redhat.com/ubi8/ubi:latest as downloader
 
 ARG PROMETHEUS_VERSION
 ARG TRINO_VERSION
@@ -36,7 +35,7 @@ RUN mkdir ${to_delete} && \
 ###########################
 
 # Final container image:
-FROM registry.access.redhat.com/ubi8/ubi:${UBI_VERSION}
+FROM registry.access.redhat.com/ubi8/ubi:latest
 
 LABEL io.k8s.display-name="OpenShift Trino" \
       io.k8s.description="This is an image used by Cost Management to install and run Trino." \


### PR DESCRIPTION
* just use the latest ubi image so we always receive the most up-to-date image when rebuilding.