### PR TITLE
Revert "Update clowdapp.yaml"

### DIFF
--- a/deploy/clowdapp.yaml
+++ b/deploy/clowdapp.yaml
@@ -502,10 +502,6 @@ objects:
           - name: MAX_HEAP_SIZE
             value: ${MAX_HEAP_SIZE}
         machinePool: ${MACHINE_POOL_OPTION}
-        tolerations:
-          - effect: NoSchedule  
-            key: hccm-trino-node
-            value: 'true'
         resources:
           limits:
             cpu: ${WORKER_CPU_LIMIT}


### PR DESCRIPTION
Reverts RedHatInsights/ubi-trino#65

We don't need this, clowder ignores tolerations 