### PR TITLE
Increase resource request for ecosystem-cert-preflight-checks

### DIFF
--- a/.tekton/pull_request.yaml
+++ b/.tekton/pull_request.yaml
@@ -49,6 +49,11 @@ spec:
               cpu: 1500m
               memory: 4Gi
 
+    - pipelineTaskName: ecosystem-cert-preflight-checks
+      computeResources:
+        requests:
+          memory: 1Gi
+
   timeouts:
     tasks: 2h
 

--- a/.tekton/push.yaml
+++ b/.tekton/push.yaml
@@ -46,6 +46,11 @@ spec:
               cpu: 1500m
               memory: 4Gi
 
+    - pipelineTaskName: ecosystem-cert-preflight-checks
+      computeResources:
+        requests:
+          memory: 1Gi
+
   timeouts:
     tasks: 2h
 


### PR DESCRIPTION
This task is getting killed by Konflux with exit 255 which indicates the resource request is too low.