### PR TITLE
remove AWS_CATALOG_ID

### DIFF
--- a/deploy/clowdapp.yaml
+++ b/deploy/clowdapp.yaml
@@ -118,7 +118,6 @@ objects:
         echo "hive.metastore.glue.aws-secret-key=$AWS_SECRET_ACCESS_KEY" >> "$GLUE_CATALOG_CONFIG"
         echo "hive.metastore.glue.default-warehouse-dir=$TRINO_S3A_OR_S3://$S3_BUCKET_NAME/data" >> "$GLUE_CATALOG_CONFIG"
         echo "hive.metastore.glue.iam-role=$AWS_ASSUME_ROLE_ARN" >> "$GLUE_CATALOG_CONFIG"
-        echo "hive.metastore.glue.catalogid=$AWS_CATALOG_ID" >> "$GLUE_CATALOG_CONFIG"
       fi
 
       ############## BLOCK TO BE REMOVED ##############
@@ -479,8 +478,6 @@ objects:
                 key: role_arn
                 name: ${AWS_ASSUME_ROLE_ARN_SECRET_NAME}
                 optional: false
-          - name: AWS_CATALOG_ID
-            value: ${AWS_CATALOG_ID}
           - name: AWS_REGION
             value: ${AWS_REGION}
           - name: TRINO_S3A_OR_S3
@@ -620,8 +617,6 @@ objects:
                 key: role_arn
                 name: ${AWS_ASSUME_ROLE_ARN_SECRET_NAME}
                 optional: false
-          - name: AWS_CATALOG_ID
-            value: ${AWS_CATALOG_ID}
           - name: AWS_REGION
             value: ${AWS_REGION}
           - name: TRINO_S3A_OR_S3
@@ -815,8 +810,6 @@ parameters:
 # AWS params
 - name: S3_BUCKET_NAME
   value: hccm-s3
-- name: AWS_CATALOG_ID
-  value: '589173575009'
 - name: AWS_REGION
   value: us-east-1
 


### PR DESCRIPTION
* specifying the catalog-id is not necessary in the glue config when utilizing a role-arn. The catalog-id is pulled from the role-arn being used.